### PR TITLE
[nix-index]: Enable comma and nix-index-database

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -111,6 +111,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1695526222,
+        "narHash": "sha256-/NwZz3QcVplrfiDKk1thYg1EIHLSNucVHNUi2uwO3RI=",
+        "owner": "Mic92",
+        "repo": "nix-index-database",
+        "rev": "25d6369c232bbea1ec1f90226fd17982e7a0a647",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1695360818,
@@ -165,6 +185,7 @@
         "home-manager": "home-manager",
         "nh": "nh",
         "nix-colors": "nix-colors",
+        "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,12 @@
     # Cool cli wrapper for flakes
     nh = {
       url = "github:viperML/nh";
-      inputs.nixpkgs.follows = "nixpkgs"; # override this repo's nixpkgs snapshot
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-index-database = {
+      url = "github:Mic92/nix-index-database";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     nix-colors.url = "github:misterio77/nix-colors";

--- a/home/global/default.nix
+++ b/home/global/default.nix
@@ -6,14 +6,16 @@
   outputs,
   ...
 }: let
-  inherit (inputs) nix-colors;
+  inherit (inputs) nix-colors nix-index-database;
   inherit (nix-colors) colorSchemes;
   inherit (nix-colors.lib-contrib {inherit pkgs;}) colorschemeFromPicture;
 in {
   imports =
     [
       ../features/common.nix
+
       nix-colors.homeManagerModule
+      nix-index-database.hmModules.nix-index
     ]
     ++ (builtins.attrValues outputs.homeManagerModules);
 
@@ -38,6 +40,7 @@ in {
   programs = {
     home-manager.enable = true;
     git.enable = true;
+    nix-index-database.comma.enable = true;
   };
 
   systemd.user.startServices = "sd-switch";


### PR DESCRIPTION
Add dependency on nix-index-database flake. Enable comma in common home manager configuration